### PR TITLE
fix missing code tag backtick

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -76,7 +76,7 @@ Note that LSI will work without these libraries, but as soon as they are install
   * macOS: `brew install openblas`
 * Install the [Numo::NArray](https://ruby-numo.github.io/narray/) and [Numo::Linalg](https://ruby-numo.github.io/linalg/) gems. If you're using Bundler, add `numo-narray` and `numo-linalg` to your Gemfile. (If using Bundler on macOS, you should set the build config like `bundle config set --global build.numo-linalg --with-openblas-dir=$(brew --prefix openblas) --with-lapack-lib="$(brew --prefix lapack)/lib"`.)
   * Ubuntu: `gem install numo-narray numo-linalg`
-  * macOS: `gem install numo-narray`, `gem install numo-linalg -- --with-openblas-dir=$(brew --prefix openblas) --with-lapack-lib="$(brew --prefix lapack)/lib"
+  * macOS: `gem install numo-narray`, `gem install numo-linalg -- --with-openblas-dir=$(brew --prefix openblas) --with-lapack-lib="$(brew --prefix lapack)/lib"`
 
 ### Install GSL Gem
 


### PR DESCRIPTION
Before:

![image](https://github.com/mkasberg/classifier-reborn/assets/753891/eed1ca68-aa85-4efa-9ef4-b09ee6adfdd6)

After:

![image](https://github.com/mkasberg/classifier-reborn/assets/753891/aaa9e99c-69dd-4b69-b541-ea828c8e10ea)
